### PR TITLE
Add Dockerfile for building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Last LTS that contains an npm version old enough to build tellstick-server/api
+FROM ubuntu:20.04
+
+# Set environment variables to avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update the package list and install necessary dependencies
+RUN apt-get update && \
+    apt-get install -y build-essential curl git gpg npm python2.7 python2.7-dev virtualenv
+
+RUN git clone --branch v1.3.2 https://github.com/telldus/tellstick-server.git /usr/src/tellstick-server
+
+# Set Python 2.7 as the default Python version
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
+
+WORKDIR /usr/src/tellstick-server
+
+# Last version to support python 2.7
+RUN echo "rsa==4.0" >> api/requirements.txt
+
+# Need to use pip version 19.2.3 because tellstick-server/sdk is using pip
+# internals to download dependencies. Tsk tsk...
+#
+# ./tellstick.sh will try to create an updated (incompatible) virtual
+# environment by default. So create a working one manually instead.
+RUN virtualenv --no-pip --python=python2.7 build/env
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && \
+    ./build/env/bin/python get-pip.py pip==19.2.3
+
+# It might be possible to get away with only "./tellstick.sh install sdk" which
+# contains the telldus_plugin command for setup.py. This builds everything.
+RUN ./tellstick.sh setup

--- a/README.md
+++ b/README.md
@@ -75,3 +75,25 @@ m41Hq9h8voY5b8hegGJmKLrJQLNOT+/rRZmuiTepmoJuyQEoQbMcRFRyyJLO+qI=
 =6Ol1
 -----END PGP PUBLIC KEY BLOCK-----
 ```
+
+## Build instructions
+
+Since the tellstick-server plugin build tools uses functions internal to pip,
+it does not work with versions later than 19.2.3. The scripts however updates
+past this version.
+
+The Dockerfile can be used to setup up a working environment and build the
+plugin.
+
+```
+sudo docker build -t tellstick-plugin-mqtt-hass-build --network=host .
+sudo -E ./build.sh
+```
+
+**Signing**
+
+The build tools expects there to be a gpg key that matches *author* and
+*author_email* of `setup.py` which is used for signing. Currently *~/.gnupg* is
+being mounted into the container and the build script may mess up the
+permissions. Be prepared to fix it with `chown -R $(id -u):$(id -g) ~/.gnupg`
+when done.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+
+read -p "This will bind mount $HOME/.gnupg into a container and may mess up permissions. Do you want to continue? " y
+case $y in
+    [Yy]* ) break;;
+    * ) exit;;
+esac
+
+docker run -it --network=host -v $(pwd):/usr/src/tellstick-server/plugins/tellstick-plugin-mqtt-hass -v $HOME/.gnupg/:/root/.gnupg tellstick-plugin-mqtt-hass-build ./tellstick.sh build-plugin plugins/tellstick-plugin-mqtt-hass/


### PR DESCRIPTION
Since the tellstick-server repository seem to be mostly abandoned it can no longer build plugins without downgrading some versions like pip.

I've created a Dockerfile that recreates an environment that works. I've only tried to build a zip file. Not actually installing it onto a device.

This should help solving #41 and #43. 